### PR TITLE
examples require fixes

### DIFF
--- a/examples/client.php
+++ b/examples/client.php
@@ -1,6 +1,6 @@
 <?php
 
-require dirname(__DIR__) . '/vendor/autoload.php';
+require __DIR__ . '/vendor/autoload.php';
 
 use Icicle\Coroutine;
 use Icicle\Http\Client\Client;

--- a/examples/server.php
+++ b/examples/server.php
@@ -1,6 +1,6 @@
 <?php
 
-require dirname(__DIR__) . '/vendor/autoload.php';
+require __DIR__ . '/vendor/autoload.php';
 
 use Icicle\Http\Message\RequestInterface;
 use Icicle\Http\Message\Response;


### PR DESCRIPTION
Fixes client.php and server.php require path in examples.
Should be `dirname(__FILE__)` or `__DIR__`, i went with latter.
