### PR TITLE
Fix function redeclare bug

### DIFF
--- a/src/Message/functions.php
+++ b/src/Message/functions.php
@@ -1,7 +1,7 @@
 <?php
 namespace Icicle\Http\Message;
 
-if (!function_exists(__NAMESPACE__ . '\encode')) {
+if (!function_exists(__NAMESPACE__ . '\encodeValue')) {
     /**
      * Escapes URI value.
      *


### PR DESCRIPTION
When I spawn a new thread using pthreads the following error occurs:

```
PHP Fatal error:  Cannot redeclare Icicle\Http\Message\encodeValue() (previously declared in /home/bohdan/projects/forwarding-proxy/vendor/icicleio/http/src/Message/functions.php:12) in /home/bohdan/projects/forwarding-proxy/vendor/icicleio/http/src/Message/functions.php on line 12
```
