### PR TITLE
Fix for ZlibDecoder::send() method

### DIFF
--- a/src/Stream/ZlibDecoder.php
+++ b/src/Stream/ZlibDecoder.php
@@ -56,10 +56,6 @@ class ZlibDecoder extends MemoryStream
             throw new FailureException('Failed adding date to inflate stream.');
         }
 
-        if ('' === $data) {
-            return 0;
-        }
-
         return yield from parent::send($data, $timeout, $end);
     }
 }


### PR DESCRIPTION
Without this fix `MemoryStream::send(..., ..., true)` will never be called, therefore, stream will never end.
