### PR TITLE
Do not encode url characters in response headers

### DIFF
--- a/src/Driver/Encoder/Http1Encoder.php
+++ b/src/Driver/Encoder/Http1Encoder.php
@@ -61,7 +61,7 @@ class Http1Encoder
     protected function encodeHeader($header)
     {
         return preg_replace_callback(
-            '/(?:[^A-Za-z0-9_\-\.~!\$&\'\(\)\[\]\*\+,:;=\/% ]+|%(?![A-Fa-f0-9]{2}))/',
+            '/(?:[^A-Za-z0-9_\-\.~!\$@#?&\'\(\)\[\]\*\+,:;=\/% ]+|%(?![A-Fa-f0-9]{2}))/',
             function (array $matches) {
                 return rawurlencode($matches[0]);
             },

--- a/tests/Driver/Encoder/Http1EncoderTest.php
+++ b/tests/Driver/Encoder/Http1EncoderTest.php
@@ -1,0 +1,39 @@
+<?php
+namespace Icicle\Tests\Http\Encoder;
+
+use Icicle\Http\Driver\Encoder\Http1Encoder;
+use Icicle\Http\Message\BasicResponse;
+use Icicle\Tests\Http\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+class Http1EncoderTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    public function getResponses()
+    {
+        return Yaml::parse(file_get_contents(dirname(dirname(__DIR__)) . '/data/responses/encoder.yml'));
+    }
+
+    /**
+     * @dataProvider getResponses
+     * @param string $filename
+     * @param int $code
+     * @param string $reason
+     * @param string $protocolVersion
+     * @param string[][] $headers
+     */
+    public function testEncodeResponse($filename, $code, $reason, $protocolVersion, $headers)
+    {
+        $encoder = new Http1Encoder();
+
+        $encoded = $encoder->encodeResponse(new BasicResponse($code, $headers, null, $reason, $protocolVersion));
+
+        $data = file_get_contents(dirname(dirname(__DIR__)) . '/data/' . $filename);
+        list($data) = explode("\r\n\r\n", $data, 2);
+        $data .= "\r\n\r\n";
+
+        $this->assertEquals($data, $encoded);
+    }
+}

--- a/tests/data/responses/19.txt
+++ b/tests/data/responses/19.txt
@@ -1,0 +1,3 @@
+HTTP/1.1 302 Found
+Location: http://www.example.org/index.php?foo=bar&bar=baz#test
+

--- a/tests/data/responses/encoder.yml
+++ b/tests/data/responses/encoder.yml
@@ -1,0 +1,7 @@
+- file: responses/19.txt
+  code: 302
+  reason: Found
+  protocolVersion: "1.1"
+  headers:
+    Location:
+      - http://www.example.org/index.php?foo=bar&bar=baz#test


### PR DESCRIPTION
We need to allow "?" in response headers to allow redirecting to an url with a query string.
