### PR TITLE
Update query string decoding to decode pluses

### DIFF
--- a/src/Message/BasicUri.php
+++ b/src/Message/BasicUri.php
@@ -444,7 +444,7 @@ class BasicUri implements Uri
             $data[] = '';
         }
 
-        return array_map(__NAMESPACE__ . '\decode', $data);
+        return array_map('urldecode', $data);
     }
 
     /**

--- a/tests/Message/BasicUriTest.php
+++ b/tests/Message/BasicUriTest.php
@@ -24,6 +24,17 @@ class BasicUriTest extends TestCase
                 'fragment-value',
             ],
             [
+                'http://example.com?foo=value1+value2',
+                'http',
+                '',
+                '',
+                'example.com',
+                80,
+                '',
+                ['foo' => ['value1 value2']],
+                '',
+            ],
+            [
                 'http://example.com/path',
                 'http',
                 '',


### PR DESCRIPTION
When decoding a query string pluses are not decoded.

This is a problem for 2 reasons:
- It doesn't match the PHP behavior.
- When using this value to create a new request the plus is encoded resulting in a different request.

Since the decode function is used to decode other parts of the URI I didn't update it and instead used urldecode directly when decoding query parts.
